### PR TITLE
Fix multi-channel 3D visualization crash in SegmentationTrainer

### DIFF
--- a/mipcandy/presets/segmentation.py
+++ b/mipcandy/presets/segmentation.py
@@ -20,6 +20,8 @@ class SegmentationTrainer(Trainer, metaclass=ABCMeta):
         if x.ndim == 3:
             visualize2d((x * 255 / x.max()).to(torch.uint16), title=title, blocking=True, screenshot_as=path)
         elif x.ndim == 4:
+            if x.shape[0] > 1:
+                x = x[0]
             visualize3d(x, title=title, max_volume=int(quality * 1e6), blocking=True, screenshot_as=path)
         else:
             raise ValueError("MIP Candy only intends to support 2D and 3D data")


### PR DESCRIPTION
- Add channel selection logic in _save_preview() for 4D tensors
- Take first channel when x.shape[0] > 1 before calling visualize3d()
- Prevents ValueError when unpacking multi-channel tensor shapes
- Maintains backward compatibility with single-channel data