### PR TITLE
`SegmentationTrainer` crashes because `"min_all" not implemented for 'UInt16'` during preview generation

### DIFF
--- a/mipcandy/presets/segmentation.py
+++ b/mipcandy/presets/segmentation.py
@@ -16,7 +16,7 @@ class SegmentationTrainer(Trainer, metaclass=ABCMeta):
     def _save_preview(self, x: torch.Tensor, title: str, quality: float) -> None:
         path = f"{self.experiment_folder()}/{title} (preview).png"
         if x.ndim == 3 and x.shape[0] in (1, 3, 4):
-            visualize2d((x * 255 / x.max()).to(torch.uint16), title=title, blocking=True, screenshot_as=path)
+            visualize2d((x * 255 / x.max()).to(torch.uint8), title=title, blocking=True, screenshot_as=path)
         elif x.ndim == 4 and x.shape[0] == 1:
             visualize3d(x, title=title, max_volume=int(quality * 1e6), blocking=True, screenshot_as=path)
 


### PR DESCRIPTION
This pull request fixes an issue in the image preview saving logic of the `SegmentationTrainer` class.
Previously, the `_save_preview` method converted 2D image tensors to `torch.uint16` before saving. However, PyTorch provides only limited support for `uint16` tensors (see [docs](https://pytorch.org/docs/stable/tensors.html)) — for example, reduction operations like `.min()` are not implemented, which caused errors in this workflow.

To resolve this, the conversion has been changed to `torch.uint8`. This data type is widely supported by image formats, avoids compatibility problems, and is more standard for visualization and preview purposes.

fix #30 