### PR TITLE
Fix `SlidingWindow` 3D metadata dimensions causing revert failure

### DIFF
--- a/mipcandy/sliding_window.py
+++ b/mipcandy/sliding_window.py
@@ -55,7 +55,7 @@ class SlidingWindow(HasDevice, metaclass=ABCMeta):
             t = torch.stack(image_windows, dim=0)
             n = t.shape[0]
             return (t.permute(0, 1, 2, 3, 4, 5).contiguous().view(b * n, c, kd, kh, kw),
-                    SWMetadata(kernel, stride, 3, b, (h, w), n))
+                    SWMetadata(kernel, stride, 3, b, (d, h, w), n))
 
     def revert_sliding_window(self, t: torch.Tensor, metadata: SWMetadata, *, clamp_min: float = 1e-8) -> torch.Tensor:
         kernel = metadata.kernel


### PR DESCRIPTION
This pull request includes a minor fix to the `do_sliding_window` method in `sliding_window.py`, ensuring that the metadata correctly records the 3D shape of the input tensor by including the depth dimension.

- Sliding window metadata fix:
  * Updated the construction of the `SWMetadata` object in `do_sliding_window` to include the depth (`d`) in the shape tuple, changing it from `(h, w)` to `(d, h, w)`.

fixed #34 