### PR TITLE
Fix preserve subclass type in `NNUNetDataset.fold()` method

### DIFF
--- a/mipcandy/data/dataset.py
+++ b/mipcandy/data/dataset.py
@@ -225,9 +225,9 @@ class NNUNetDataset(SupervisedDataset[list[str]]):
     def construct_new(self, images: D, labels: D) -> Self:
         if self._folded:
             raise ValueError("Cannot construct a new dataset from a fold")
-        new = type(self)(self._folder, split=self._split, prefix=self._prefix, align_spacing=self._align_spacing,
-                         image_transform=self._image_transform, label_transform=self._label_transform,
-                         device=self._device)
+        new = self.__class__(self._folder, split=self._split, prefix=self._prefix, align_spacing=self._align_spacing,
+                             image_transform=self._image_transform, label_transform=self._label_transform,
+                             device=self._device)
         new._images = images
         new._labels = labels
         new._folded = True


### PR DESCRIPTION
This pull request makes a targeted improvement to the dataset construction logic. Instead of hardcoding the class in the `construct_new` method, it now uses the dynamic type of the current instance, which increases flexibility and makes the method safer for subclasses.

- Dataset construction:
  * Updated the `construct_new` method to instantiate new datasets using `type(self)` instead of the hardcoded `NNUNetDataset` class, improving subclass compatibility.

fixed #38 