### PR TITLE
fixed off_screen pass timing

### DIFF
--- a/mipcandy/data/visualization.py
+++ b/mipcandy/data/visualization.py
@@ -45,10 +45,9 @@ def visualize2d(image: torch.Tensor, *, title: str | None = None, cmap: str = "g
 def _visualize3d_with_pyvista(image: np.ndarray, title: str | None, cmap: str,
                               screenshot_as: str | PathLike[str] | None) -> None:
     from pyvista import Plotter
-    p = Plotter(title=title)
+    p = Plotter(title=title, off_screen=bool(screenshot_as))
     p.add_volume(image, cmap=cmap)
     if screenshot_as:
-        p.off_screen = True
         p.screenshot(screenshot_as)
     else:
         p.show()


### PR DESCRIPTION
This pull request makes a focused improvement to the 3D visualization workflow in `mipcandy/data/visualization.py`. The main change ensures that when a screenshot is requested, the `Plotter` is created in off-screen mode, which is the correct way to capture screenshots without displaying a window.

Visualization update:

* In the `_visualize3d_with_pyvista` function, the `Plotter` is now initialized with `off_screen=True` if a screenshot is requested, instead of setting `p.off_screen` after creation. This ensures proper off-screen rendering for screenshots.