### PR TITLE
Redundant logging in `train()`

### DIFF
--- a/mipcandy/training.py
+++ b/mipcandy/training.py
@@ -203,7 +203,7 @@ class Trainer(WithPaddingModule, metaclass=ABCMeta):
                 loss, metrics = self.train_batch(images, labels, toolbox)
                 self.record("combined loss", loss)
                 self.record_all(metrics)
-                progress.update(epoch_prog, advance=1, description=f"Training epoch {epoch} {tuple(image.shape)}")
+                progress.update(epoch_prog, advance=1, description=f"Training epoch {epoch} {tuple(images.shape)}")
         self._bump_metrics()
 
     @abstractmethod

--- a/mipcandy/training.py
+++ b/mipcandy/training.py
@@ -203,7 +203,7 @@ class Trainer(WithPaddingModule, metaclass=ABCMeta):
                 loss, metrics = self.train_batch(images, labels, toolbox)
                 self.record("combined loss", loss)
                 self.record_all(metrics)
-                progress.update(epoch_prog, advance=1, description=f"Training epoch {epoch} ({loss:.4f})")
+                progress.update(epoch_prog, advance=1, description=f"Training epoch {epoch} ({"x".join(images.shape)})")
         self._bump_metrics()
 
     @abstractmethod
@@ -235,7 +235,7 @@ class Trainer(WithPaddingModule, metaclass=ABCMeta):
                     self._worst_case = (image, label, mask)
                     worst_score = case_score
                 try_append_all(case_metrics, metrics)
-                progress.update(val_prog, advance=1, description=f"Validating ({case_score:.4f})")
+                progress.update(val_prog, advance=1, description=f"Validating ({"x".join(image.shape)})")
         return score / num_cases, metrics
 
     def predict_maximum_validation_score(self, num_epochs: int, *, degree: int = 5) -> tuple[int, float]:

--- a/mipcandy/training.py
+++ b/mipcandy/training.py
@@ -342,8 +342,7 @@ class Trainer(WithPaddingModule, metaclass=ABCMeta):
                 self.train_epoch(epoch, toolbox)
                 lr = scheduler.get_last_lr()[0]
                 self._record("learning rate", lr)
-                self.log(f"Learning rate: {lr}")
-                self.show_metrics(epoch, skip=lambda m, _: m.startswith("val "))
+                self.show_metrics(epoch, skip=lambda m, _: m.startswith("val ") or m == "epoch duration")
                 torch.save(model.state_dict(), checkpoint_path("latest"))
                 if epoch % (num_epochs / num_checkpoints) == 0:
                     copy(checkpoint_path("latest"), checkpoint_path(epoch))

--- a/mipcandy/training.py
+++ b/mipcandy/training.py
@@ -203,7 +203,7 @@ class Trainer(WithPaddingModule, metaclass=ABCMeta):
                 loss, metrics = self.train_batch(images, labels, toolbox)
                 self.record("combined loss", loss)
                 self.record_all(metrics)
-                progress.update(epoch_prog, advance=1, description=f"Training epoch {epoch} ({"x".join(images.shape)})")
+                progress.update(epoch_prog, advance=1, description=f"Training epoch {epoch} {tuple(image.shape)}")
         self._bump_metrics()
 
     @abstractmethod
@@ -235,7 +235,7 @@ class Trainer(WithPaddingModule, metaclass=ABCMeta):
                     self._worst_case = (image, label, mask)
                     worst_score = case_score
                 try_append_all(case_metrics, metrics)
-                progress.update(val_prog, advance=1, description=f"Validating ({"x".join(image.shape)})")
+                progress.update(val_prog, advance=1, description=f"Validating {tuple(image.shape)}")
         return score / num_cases, metrics
 
     def predict_maximum_validation_score(self, num_epochs: int, *, degree: int = 5) -> tuple[int, float]:


### PR DESCRIPTION
See #64.