### PR TITLE
Incorrect unpacking order of paddings in Restore3d causes dimension mismatch

### DIFF
--- a/mipcandy/common/module/preprocess.py
+++ b/mipcandy/common/module/preprocess.py
@@ -110,7 +110,7 @@ class Restore3d(nn.Module):
         paddings = self.conjugate_padding.paddings()
         if not paddings:
             raise ValueError("Paddings are not set yet, did you forget to pad before restoring?")
-        pad_h0, pad_h1, pad_w0, pad_w1, pad_d0, pad_d1 = paddings
+        pad_d0, pad_d1, pad_h0, pad_h1, pad_w0, pad_w1 = paddings
         if self.conjugate_padding.batch:
             _, _, d, h, w = x.shape
             return x[:, :, pad_d0: d - pad_d1, pad_h0: h - pad_h1, pad_w0: w - pad_w1]


### PR DESCRIPTION
This pull request corrects the order in which padding values are unpacked in the `forward` method of the `mipcandy/common/module/preprocess.py` file. This change ensures that the dimensions are sliced correctly when restoring padded tensors.

Tensor padding fix:

* Corrected the unpacking order of padding values in the `forward` method to match the expected (depth, height, width) order, preventing incorrect slicing of tensor dimensions.

fixed #114 