### PR TITLE
SlidingTrainer: compute validation metrics on reconstructed full volume

### DIFF
--- a/mipcandy/presets/segmentation.py
+++ b/mipcandy/presets/segmentation.py
@@ -70,7 +70,10 @@ class SlidingSegmentationTrainer(SlidingTrainer, SegmentationTrainer, metaclass=
     @override
     def backward_windowed(self, images: torch.Tensor, labels: torch.Tensor, toolbox: TrainerToolbox,
                           metadata: SWMetadata) -> tuple[float, dict[str, float]]:
-        return SegmentationTrainer.backward(self, images, labels, toolbox)
+        mask = self.forward(images, toolbox, use_ema=False)
+        loss, metrics = toolbox.criterion(mask, labels)
+        loss.backward()
+        return loss.item(), metrics
 
     @override
     def compute_metrics(self, output: torch.Tensor, label: torch.Tensor, toolbox: TrainerToolbox) -> tuple[


### PR DESCRIPTION
This pull request refactors the windowed validation logic for segmentation training. The main changes involve separating prediction and metric computation into distinct methods, improving code clarity and modularity. The abstract interface is also updated to reflect these changes.

**Refactoring validation and metrics computation:**

* Introduced a new `predict_windowed` method in `mipcandy/training.py` to handle model prediction separately from metric computation.
* Replaced the abstract `validate_case_windowed` method with a more focused `compute_metrics` method in both `mipcandy/training.py` and `mipcandy/presets/segmentation.py`, which now only computes loss and metrics from model outputs and labels. [[1]](diffhunk://#diff-f5d70378e3578763f8f5b0eca2163038bf7dac3edf9c53c6fc345b2878a63aa9R534-R551) [[2]](diffhunk://#diff-6a4262c1366ae8098d75d435fc9f5c00b357a5852545c7afa11638c4573cca64L76-R82)

**Interface and type improvements:**

* Updated `get_window_shape` in `mipcandy/presets/segmentation.py` to specify its return type more precisely.
* Adjusted the implementation of `validate_case` in `mipcandy/training.py` to use the new prediction and metric computation methods, streamlining the validation workflow.